### PR TITLE
Mg crud snack mood

### DIFF
--- a/SweetTooth.ui/src/components/AdminDashboard.js
+++ b/SweetTooth.ui/src/components/AdminDashboard.js
@@ -19,6 +19,9 @@ function AdminDashboard() {
       case 'snacks':
         history.push('/admin-snacks');
         break;
+      case 'snackMoods':
+        history.push('/admin-snack-moods');
+        break;
       default: console.warn('select a valid option');
     }
   };
@@ -28,6 +31,7 @@ function AdminDashboard() {
       <Button onClick={() => handleClick('orders')}>Orders</Button>
       <Button onClick={() => handleClick('moods')}>Moods</Button>
       <Button onClick={() => handleClick('snacks')}>Snacks</Button>
+      <Button onClick={() => handleClick('snackMoods')}>SnackMoods</Button>
       <Button onClick={() => handleClick('users')}>Users</Button>
     </div>
   );

--- a/SweetTooth.ui/src/components/SnackMoodAdmin.js
+++ b/SweetTooth.ui/src/components/SnackMoodAdmin.js
@@ -3,6 +3,9 @@ import { Button } from 'reactstrap';
 import { useHistory } from 'react-router-dom';
 import { getSnackMoods } from '../helpers/data/SnackMood';
 import SnackMoodCard from './SnackMoodCard';
+import SnackMoodForm from './forms/SnackMoodForm';
+import { getSnacks } from '../helpers/data/SnackData';
+import { getMoods } from '../helpers/data/MoodData';
 
 function SnackMoodAdmin() {
   const history = useHistory();
@@ -12,13 +15,23 @@ function SnackMoodAdmin() {
   };
 
   const [snackMoods, setSnackMoods] = useState([]);
+  const [snacks, setSnacks] = useState([]);
+  const [moods, setMoods] = useState([]);
+
   useEffect(() => {
     getSnackMoods().then(setSnackMoods);
+    getSnacks().then(setSnacks);
+    getMoods().then(setMoods);
   }, []);
 
   return (
     <div>
       <Button onClick={returnToDashboard}>Return to Dashboard</Button>
+      <SnackMoodForm
+            snacks={snacks}
+            moods={moods}
+            setSnackMoods={setSnackMoods}
+          />
       <table className='table'>
         <thead>
           <tr>
@@ -30,14 +43,6 @@ function SnackMoodAdmin() {
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td></td>
-            <td>enter MoodId</td>
-            <td>enter SnackId</td>
-            <td>corresponding MoodName</td>
-            <td>corresponding SnackName</td>
-            <td><button type='submit' className="btn btn-outline-success btn-sm">Add</button></td>
-          </tr>
           {
             snackMoods.map((snackMood) => (
               <SnackMoodCard

--- a/SweetTooth.ui/src/components/SnackMoodAdmin.js
+++ b/SweetTooth.ui/src/components/SnackMoodAdmin.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from 'reactstrap';
+import { useHistory } from 'react-router-dom';
+import { getSnackMoods } from '../helpers/data/SnackMood';
+import SnackMoodCard from './SnackMoodCard';
+
+function SnackMoodAdmin() {
+  const history = useHistory();
+
+  const returnToDashboard = () => {
+    history.push('/admin-dashboard');
+  };
+
+  const [snackMoods, setSnackMoods] = useState([]);
+  useEffect(() => {
+    getSnackMoods().then(setSnackMoods);
+  }, []);
+
+  return (
+    <div>
+      <Button onClick={returnToDashboard}>Return to Dashboard</Button>
+      <table className='table'>
+        <thead>
+          <tr>
+            <th scope='col'>id</th>
+            <th scope='col'>moodId</th>
+            <th scope='col'>snackId</th>
+            <th scope='col'>moodName</th>
+            <th scope='col'>snackName</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td></td>
+            <td>enter MoodId</td>
+            <td>enter SnackId</td>
+            <td>corresponding MoodName</td>
+            <td>corresponding SnackName</td>
+            <td><button type='submit' className="btn btn-outline-success btn-sm">Add</button></td>
+          </tr>
+          {
+            snackMoods.map((snackMood) => (
+              <SnackMoodCard
+                key={snackMood.id}
+                id={snackMood.id}
+                moodId={snackMood.moodId}
+                snackId={snackMood.snackId}
+                moodName={snackMood.moodName}
+                snackName={snackMood.snackName}
+                setSnackMoods={setSnackMoods}
+              />
+            ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default SnackMoodAdmin;

--- a/SweetTooth.ui/src/components/SnackMoodCard.js
+++ b/SweetTooth.ui/src/components/SnackMoodCard.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { deleteSnackMood } from '../helpers/data/SnackMood';
+
+function SnackMoodCard({
+  id,
+  moodId,
+  snackId,
+  moodName,
+  snackName,
+  setSnackMoods
+}) {
+  return (
+    <tr>
+      <td>{id}</td>
+      <td>{moodId}</td>
+      <td>{snackId}</td>
+      <td>{moodName}</td>
+      <td>{snackName}</td>
+      <td><button type='submit' className="btn btn-outline-danger btn-sm" onClick={() => deleteSnackMood(id).then(setSnackMoods)}>Delete</button></td>
+    </tr>
+  );
+}
+
+SnackMoodCard.propTypes = {
+  id: PropTypes.string,
+  moodId: PropTypes.string,
+  snackId: PropTypes.string,
+  moodName: PropTypes.string,
+  snackName: PropTypes.string,
+  setSnackMoods: PropTypes.func
+};
+
+export default SnackMoodCard;

--- a/SweetTooth.ui/src/components/forms/SnackMoodForm.js
+++ b/SweetTooth.ui/src/components/forms/SnackMoodForm.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Form, FormGroup, Input, Button, Container
+} from 'reactstrap';
+import { addSnackMood } from '../../helpers/data/SnackMood';
+
+function SnackMoodForm({
+  moods, snacks, setSnackMoods
+}) {
+  const [snackMoodObj, setSnackMoodObj] = useState({
+    MoodId: '',
+    SnackId: ''
+  });
+
+  const handleInputChange = (e) => {
+    setSnackMoodObj((prevState) => ({
+      ...prevState,
+      [e.target.name]: e.target.value
+    }));
+  };
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    addSnackMood(snackMoodObj).then(setSnackMoods);
+  };
+
+  return (
+    <Container>
+      Add a New SnackMood
+      <Form autoComplete='off' onSubmit={handleSubmit}>
+        <FormGroup>
+          <Input
+            id='moodName'
+            type='select'
+            name='MoodId'
+            placeholder=''
+            required
+            onChange={handleInputChange}
+          >
+            <option value=''>Select a Mood</option>
+            {moods.map((mood) => (
+              <option
+                key={mood.id}
+                value={mood.id}
+              >{mood.name}</option>
+            ))}
+          </Input>
+        </FormGroup>
+        <FormGroup>
+          <Input
+            id='snackName'
+            type='select'
+            name='SnackId'
+            placeholder=''
+            required
+            onChange={handleInputChange}
+          >
+            <option value=''>Select a Snack</option>
+            {snacks.map((snack) => (
+              <option
+                key={snack.id}
+                value={snack.id}
+              >{snack.name}</option>
+            ))}
+          </Input>
+        </FormGroup>
+        <Button type='submit' className="btn btn-outline-success btn-sm">Add</Button>
+      </Form>
+    </Container >
+  );
+}
+
+export default SnackMoodForm;
+
+SnackMoodForm.propTypes = {
+  moods: PropTypes.array,
+  snacks: PropTypes.array,
+  setSnackMoods: PropTypes.func
+};

--- a/SweetTooth.ui/src/helpers/Routes.js
+++ b/SweetTooth.ui/src/helpers/Routes.js
@@ -15,6 +15,7 @@ import OrdersAdmin from '../components/OrdersAdmin';
 import UsersAdmin from '../components/UsersAdmin';
 import MoodsAdmin from '../components/MoodsAdmin';
 import SnacksAdmin from '../components/SnacksAdmin';
+import SnackMoodAdmin from '../components/SnackMoodAdmin';
 
 const PrivateRoute = ({ component: Component, user, ...rest }) => {
   const routeChecker = (remainder) => (user
@@ -70,9 +71,9 @@ function Routes({
             orderItems={orderItems}
             setOrder={setOrder}
             setOrderItems={setOrderItems}
-        />
-      }
-        user={user}
+          />
+          }
+          user={user}
         />
         <PrivateRoute
           exact path="/user-profile"
@@ -95,35 +96,39 @@ function Routes({
           user={user}
         />
         <PrivateRoute
-        exact path='/processed'
-        component={() => <Processed
-        user={user}
-        />
-        }
-        user={user}
-        />
-         <PrivateRoute
-        exact path='/admin-orders'
-        component={OrdersAdmin}
-        user={user}
+          exact path='/processed'
+          component={() => <Processed
+            user={user}
+          />
+          }
+          user={user}
         />
         <PrivateRoute
-        exact path='/admin-users'
-        component={UsersAdmin}
-        user={user}
+          exact path='/admin-orders'
+          component={OrdersAdmin}
+          user={user}
         />
-          <PrivateRoute
-        exact path='/admin-moods'
-        component={MoodsAdmin}
-        user={user}
+        <PrivateRoute
+          exact path='/admin-users'
+          component={UsersAdmin}
+          user={user}
         />
-          <PrivateRoute
-        exact path='/admin-snacks'
-        component={() => <SnacksAdmin
-        snacks={snacks}
+        <PrivateRoute
+          exact path='/admin-moods'
+          component={MoodsAdmin}
+          user={user}
         />
-      }
-        user={user}
+        <PrivateRoute
+          exact path='/admin-snacks'
+          component={() => <SnacksAdmin
+            snacks={snacks}
+          />}
+          user={user}
+        />
+        <PrivateRoute
+          exact path='/admin-snack-moods'
+          component={() => <SnackMoodAdmin />}
+          user={user}
         />
       </Switch>
     </div>

--- a/SweetTooth.ui/src/helpers/data/SnackMood.js
+++ b/SweetTooth.ui/src/helpers/data/SnackMood.js
@@ -20,13 +20,13 @@ const getSnackMoodById = (id) => new Promise((resolve, reject) => {
 // endpoint yields object
 const addSnackMood = (snackMood) => new Promise((resolve, reject) => {
   axios.post(`${dbUrl}/snackMood`, snackMood)
-    .then(() => getSnackMoods())
+    .then(() => getSnackMoods().then(resolve))
     .catch((error) => reject(error));
 });
 
 const deleteSnackMood = (id) => new Promise((resolve, reject) => {
   axios.delete(`${dbUrl}/snackMood/${id}`)
-    .then(() => getSnackMoods())
+    .then(() => getSnackMoods().then(resolve))
     .catch((error) => reject(error));
 });
 

--- a/SweetTooth.ui/src/helpers/data/SnackMood.js
+++ b/SweetTooth.ui/src/helpers/data/SnackMood.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import firebaseConfig from '../apiKeys';
+
+const dbUrl = firebaseConfig.databaseURL;
+
+// endpoint yields array of objects
+const getSnackMoods = () => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/snackMood`)
+    .then((response) => resolve(Object.values(response.data)))
+    .catch((error) => reject(error));
+});
+
+// endpoint yields object
+const getSnackMoodById = (id) => new Promise((resolve, reject) => {
+  axios.get(`${dbUrl}/snackMood/${id}`)
+    .then((response) => resolve(response.data))
+    .catch((error) => reject(error));
+});
+
+// endpoint yields object
+const addSnackMood = (snackMood) => new Promise((resolve, reject) => {
+  axios.post(`${dbUrl}/snackMood`, snackMood)
+    .then(() => getSnackMoods())
+    .catch((error) => reject(error));
+});
+
+const deleteSnackMood = (id) => new Promise((resolve, reject) => {
+  axios.delete(`${dbUrl}/snackMood/${id}`)
+    .then(() => getSnackMoods())
+    .catch((error) => reject(error));
+});
+
+export {
+  getSnackMoods, getSnackMoodById, addSnackMood, deleteSnackMood
+};

--- a/SweetTooth/Controllers/SnackMoodController.cs
+++ b/SweetTooth/Controllers/SnackMoodController.cs
@@ -19,6 +19,12 @@ namespace SweetTooth.Controllers
             _snackMoodRepo = snackMoodRepo;
         }
 
+        [HttpGet]
+        public IActionResult GetAllSnackMoods()
+        {
+            return Ok(_snackMoodRepo.GetAll());
+        }
+
         [HttpGet("{id}")]
         public IActionResult GetSnackMoodById(Guid id)
         {

--- a/SweetTooth/Controllers/SnackMoodController.cs
+++ b/SweetTooth/Controllers/SnackMoodController.cs
@@ -41,8 +41,12 @@ namespace SweetTooth.Controllers
         [HttpPost]
         public IActionResult AddSnackMood(SnackMood newSnackMood)
         {
+            var snackMoodExists = _snackMoodRepo.GetBySnackIdAndMoodId(newSnackMood.MoodId, newSnackMood.SnackId);
+            if (snackMoodExists != null)
+                return BadRequest("SnackMood combination already exists.");
+
             if (newSnackMood.MoodId == Guid.Empty || newSnackMood.SnackId == Guid.Empty)
-                return BadRequest("Snack and Mood Id's are required.");
+                return BadRequest("Snack and/or Mood Id's are required.");
 
             _snackMoodRepo.Add(newSnackMood);
 

--- a/SweetTooth/DataAccess/SnackMoodRepo.cs
+++ b/SweetTooth/DataAccess/SnackMoodRepo.cs
@@ -37,7 +37,8 @@ namespace SweetTooth.DataAccess
 
             var sql = @"select sm.*, m.Name [MoodName], s.Name [SnackName] from SnackMood sm
                         left join Mood m on sm.MoodId = m.Id
-                        left join Snack s on sm.SnackId = s.Id";
+                        left join Snack s on sm.SnackId = s.Id
+                        order by s.Name asc";
             var snackMoods = db.Query<SnackMood>(sql);
 
             return snackMoods;

--- a/SweetTooth/DataAccess/SnackMoodRepo.cs
+++ b/SweetTooth/DataAccess/SnackMoodRepo.cs
@@ -44,6 +44,19 @@ namespace SweetTooth.DataAccess
             return snackMoods;
         }
 
+        internal object GetBySnackIdAndMoodId(Guid moodId, Guid snackId)
+        {
+            using var db = new SqlConnection(_connectionString);
+
+            var sql = @"select * from SnackMood 
+                        where MoodId = @moodId
+                        and SnackId = @snackId";
+
+            var snackMood = db.QuerySingleOrDefault<SnackMood>(sql, new { moodId, snackId });
+
+            return snackMood;
+        }
+
         internal SnackMood GetById(Guid id)
         {
             using var db = new SqlConnection(_connectionString);

--- a/SweetTooth/DataAccess/SnackMoodRepo.cs
+++ b/SweetTooth/DataAccess/SnackMoodRepo.cs
@@ -31,6 +31,18 @@ namespace SweetTooth.DataAccess
 
         }
 
+        internal IEnumerable<SnackMood> GetAll()
+        {
+            using var db = new SqlConnection(_connectionString);
+
+            var sql = @"select sm.*, m.Name [MoodName], s.Name [SnackName] from SnackMood sm
+                        left join Mood m on sm.MoodId = m.Id
+                        left join Snack s on sm.SnackId = s.Id";
+            var snackMoods = db.Query<SnackMood>(sql);
+
+            return snackMoods;
+        }
+
         internal SnackMood GetById(Guid id)
         {
             using var db = new SqlConnection(_connectionString);

--- a/SweetTooth/Models/SnackMood.cs
+++ b/SweetTooth/Models/SnackMood.cs
@@ -10,5 +10,7 @@ namespace SweetTooth.Models
         public Guid Id { get; set; }
         public Guid MoodId { get; set; }
         public Guid SnackId { get; set; }
+        public string MoodName { get; set; }
+        public string SnackName { get; set;  }
     }
 }


### PR DESCRIPTION
## Description
Admin can now view from the admin/snackMood page all existing snackmoods, can create new ones, and can delete existing ones.
Built backend logic to enable this, and frontend page, table, form to add, and delete buttons.
Built backend logic to see if snackMood combo already exists

## Related Issue

#113 

## Motivation and Context
So admin can easily adjust relationships between snacks and moods

## How Can This Be Tested?
git fetch, test the SnackMood page from the Admin page.
Try adding new combos, deleting existing ones.
Try adding an existing combo. You should not be able to.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
